### PR TITLE
Implement full .hbs -> .gjs codemod

### DIFF
--- a/bin/ember-codemod-template-tag.ts
+++ b/bin/ember-codemod-template-tag.ts
@@ -25,6 +25,7 @@ const argv = yargs(hideBin(process.argv))
 
 const codemodOptions: CodemodOptions = {
   appName: argv['app-name'] ?? 'example-app',
+  filename: 'nope',
   projectRoot: argv['root'] ?? process.cwd(),
 };
 

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "@codemod-utils/ast-javascript": "^1.2.0",
     "@codemod-utils/ast-template": "^1.1.0",
     "@codemod-utils/files": "^1.1.0",
+    "@glimmer/syntax": "^0.85.12",
     "change-case": "^5.1.2",
     "content-tag": "^1.1.2",
     "recast": "^0.23.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -22,6 +22,9 @@ dependencies:
   '@codemod-utils/files':
     specifier: ^1.1.0
     version: 1.1.0
+  '@glimmer/syntax':
+    specifier: ^0.85.12
+    version: 0.85.12
   change-case:
     specifier: ^5.1.2
     version: 5.1.2
@@ -611,6 +614,12 @@ packages:
     dependencies:
       '@simple-dom/interface': 1.4.0
 
+  /@glimmer/interfaces@0.85.12:
+    resolution: {integrity: sha512-ethjad78QPy55VgLxkmYSxHQhfbXj0718ICZcg36FlstNIOKtd0lqTar1BXkRBXn30pcwgtj8r7aq+r2FDwvQQ==}
+    dependencies:
+      '@simple-dom/interface': 1.4.0
+    dev: false
+
   /@glimmer/reference@0.84.3:
     resolution: {integrity: sha512-lV+p/aWPVC8vUjmlvYVU7WQJsLh319SdXuAWoX/SE3pq340BJlAJiEcAc6q52y9JNhT57gMwtjMX96W5Xcx/qw==}
     dependencies:
@@ -628,6 +637,16 @@ packages:
       '@handlebars/parser': 2.0.0
       simple-html-tokenizer: 0.5.11
 
+  /@glimmer/syntax@0.85.12:
+    resolution: {integrity: sha512-PopX/DzIogOeaQRRqZPWWkD8UYL1uNhip0IdmHElXQOZScICsgd2k7HN7lZbTDwlGmMil3Szj+PrhUNhqT8znQ==}
+    dependencies:
+      '@glimmer/interfaces': 0.85.12
+      '@glimmer/util': 0.85.12
+      '@glimmer/wire-format': 0.85.12
+      '@handlebars/parser': 2.0.0
+      simple-html-tokenizer: 0.5.11
+    dev: false
+
   /@glimmer/util@0.84.3:
     resolution: {integrity: sha512-qFkh6s16ZSRuu2rfz3T4Wp0fylFj3HBsONGXQcrAdZjdUaIS6v3pNj6mecJ71qRgcym9Hbaq/7/fefIwECUiKw==}
     dependencies:
@@ -635,11 +654,25 @@ packages:
       '@glimmer/interfaces': 0.84.3
       '@simple-dom/interface': 1.4.0
 
+  /@glimmer/util@0.85.12:
+    resolution: {integrity: sha512-11LZwIw0A4xxH68e7SnJcMx+cqt6K4+qlRgxPqTwpRhg+kzI9qp0LySt96jFPE8YA2+GZz5G2DK4IhF+iJFnNQ==}
+    dependencies:
+      '@glimmer/env': 0.1.7
+      '@glimmer/interfaces': 0.85.12
+    dev: false
+
   /@glimmer/validator@0.84.3:
     resolution: {integrity: sha512-RTBV4TokUB0vI31UC7ikpV7lOYpWUlyqaKV//pRC4pexYMlmqnVhkFrdiimB/R1XyNdUOQUmnIAcdic39NkbhQ==}
     dependencies:
       '@glimmer/env': 0.1.7
       '@glimmer/global-context': 0.84.3
+
+  /@glimmer/wire-format@0.85.12:
+    resolution: {integrity: sha512-lZyWeQ43uG867lgHXge28smmOS66yTxe3DxewhucJ5pgSoA25fp3H9edFVrKWAP0ymYldde9VfMhKfkAoJLq8w==}
+    dependencies:
+      '@glimmer/interfaces': 0.85.12
+      '@glimmer/util': 0.85.12
+    dev: false
 
   /@handlebars/parser@2.0.0:
     resolution: {integrity: sha512-EP9uEDZv/L5Qh9IWuMUGJRfwhXJ4h1dqKTT4/3+tY0eu7sPis7xh23j61SYUnNF4vqCQvvUXpDo9Bh/+q1zASA==}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,12 +1,93 @@
-import { changeExtension } from './steps/change-extension.js';
-import { convertTests, createOptions } from './steps/index.js';
-import { removeHbsImport } from './steps/remove-import.js';
+import { execSync } from 'node:child_process';
+
+import { findFiles } from '@codemod-utils/files';
+
+import finalize from './steps/finalize.js';
+import { createOptions } from './steps/index.js';
+import inlineTemplate from './steps/inline-template.js';
+import renameJsToGjs from './steps/rename-js-to-gjs.js';
+import resolveImports from './steps/resolve-imports.js';
 import type { CodemodOptions } from './types/index.js';
 
 export function runCodemod(codemodOptions: CodemodOptions): void {
   const options = createOptions(codemodOptions);
 
-  convertTests(options);
-  changeExtension(options);
-  removeHbsImport(options);
+  const candidates = findFiles('**/*.hbs', {
+    ignoreList: ['**/templates/**/*.hbs'],
+    projectRoot: codemodOptions.projectRoot,
+  });
+
+  const converted: string[] = [];
+  const skipped: [string, string][] = [];
+
+  for (const candidate of candidates) {
+    const goodRef = execSync('git rev-parse HEAD', {
+      cwd: options.projectRoot,
+      encoding: 'utf8',
+    }).trim();
+
+    try {
+      console.log(`Converting ${candidate}`);
+
+      execSync(`git reset --hard ${goodRef}`, {
+        cwd: options.projectRoot,
+        encoding: 'utf8',
+        stdio: 'ignore',
+      });
+
+      options.filename = candidate;
+
+      renameJsToGjs(options);
+      resolveImports(options);
+      inlineTemplate(options);
+      finalize(options);
+
+      console.log(
+        execSync(`git show --color HEAD~`, {
+          cwd: options.projectRoot,
+          encoding: 'utf8',
+        }),
+      );
+
+      converted.push(candidate);
+    } catch (error: unknown) {
+      let reason = String(error);
+
+      if (error instanceof Error) {
+        reason = error.message;
+      }
+
+      reason = reason.trim();
+
+      console.warn(`Failed to convert ${candidate}: ${reason}`);
+
+      execSync(`git reset --hard ${goodRef}`, {
+        cwd: options.projectRoot,
+        stdio: 'ignore',
+      });
+
+      skipped.push([candidate, reason]);
+    }
+  }
+
+  if (converted.length) {
+    console.log('Successfully converted %d files:\n', converted.length);
+
+    for (const file of converted) {
+      console.log(`- ${file}`);
+    }
+
+    console.log('\n');
+  }
+
+  if (skipped.length) {
+    console.log('Skipped %d files:\n', skipped.length);
+
+    for (const [file, reason] of skipped) {
+      console.log(`- ${file}`);
+      console.log(`  ${reason}`);
+    }
+
+    console.log('\n');
+  }
 }

--- a/src/steps/create-options.ts
+++ b/src/steps/create-options.ts
@@ -1,10 +1,11 @@
 import type { CodemodOptions, Options } from '../types/index.js';
 
 export function createOptions(codemodOptions: CodemodOptions): Options {
-  const { appName: appName, projectRoot } = codemodOptions;
+  const { appName, filename, projectRoot } = codemodOptions;
 
   return {
-    appName: appName,
+    appName,
+    filename,
     projectRoot,
   };
 }

--- a/src/steps/finalize.ts
+++ b/src/steps/finalize.ts
@@ -1,0 +1,49 @@
+import { execSync } from 'node:child_process';
+import { unlinkSync } from 'node:fs';
+import path from 'node:path';
+
+import type { Options } from '../types/index.js';
+
+export default function finalize(options: Options): void {
+  const hbs = path.join(options.projectRoot, options.filename);
+
+  const gjs = path.join(
+    options.projectRoot,
+    options.filename.replace('.hbs', '.gjs'),
+  );
+
+  execSync(`yarn eslint --fix ${JSON.stringify(gjs)}`, {
+    cwd: options.projectRoot,
+  });
+
+  execSync(`yarn prettier --write ${JSON.stringify(gjs)}`, {
+    cwd: options.projectRoot,
+  });
+
+  execSync(`yarn ember-template-lint --fix ${JSON.stringify(hbs)}`, {
+    cwd: options.projectRoot,
+  });
+
+  execSync(`yarn prettier --write ${JSON.stringify(hbs)}`, {
+    cwd: options.projectRoot,
+  });
+
+  const label = path.basename(options.filename).replace('.hbs', '');
+  const convert = JSON.stringify(`DEV: convert chat/${label} -> gjs`);
+
+  execSync('git add .', { cwd: options.projectRoot });
+  execSync(`git commit -m ${convert}`, {
+    cwd: options.projectRoot,
+    stdio: 'ignore',
+  });
+
+  unlinkSync(hbs);
+
+  const cleanup = JSON.stringify(`DEV: cleanup chat/${label}`);
+
+  execSync('git add .', { cwd: options.projectRoot });
+  execSync(`git commit -m ${cleanup}`, {
+    cwd: options.projectRoot,
+    stdio: 'ignore',
+  });
+}

--- a/src/steps/inline-template.ts
+++ b/src/steps/inline-template.ts
@@ -1,0 +1,73 @@
+import { readFileSync, writeFileSync } from 'node:fs';
+import path from 'node:path';
+
+import { AST } from '@codemod-utils/ast-javascript';
+
+import type { Options } from '../types/index.js';
+
+export default function inlineTemplate(options: Options): void {
+  const hbs = path.join(options.projectRoot, options.filename);
+
+  const hbsSource = readFileSync(hbs, { encoding: 'utf8' });
+
+  const gjs = path.join(
+    options.projectRoot,
+    options.filename.replace('.hbs', '.gjs'),
+  );
+
+  const jsSource = readFileSync(gjs, { encoding: 'utf8' });
+
+  const traverse = AST.traverse(false);
+
+  let found = 0;
+
+  const ast = traverse(jsSource, {
+    visitClassDeclaration(path) {
+      if (
+        path.node.superClass?.type === 'Identifier' &&
+        path.node.superClass.name === 'Component'
+      ) {
+        found++;
+
+        path.node.body.body.push(
+          AST.builders.classProperty(
+            AST.builders.identifier('__template__'),
+            null,
+          ),
+        );
+      }
+
+      return false;
+    },
+  });
+
+  if (found === 0) {
+    throw new Error('cannot find class');
+  } else if (found > 1) {
+    throw new Error('too many classes?');
+  }
+
+  const jsPlaceholder = AST.print(ast);
+
+  const matches = [...jsPlaceholder.matchAll(/^\s*__template__;$/gm)];
+
+  if (matches.length === 0) {
+    throw new Error('cannot find placeholder');
+  } else if (matches.length > 1) {
+    throw new Error('too many placeholders?');
+  }
+
+  let templateTag = `\n`;
+
+  templateTag += `  <template>\n`;
+
+  for (const line of hbsSource.split('\n')) {
+    templateTag += `    ${line}\n`;
+  }
+
+  templateTag += `  </template>`;
+
+  const gjsSource = jsPlaceholder.replace(/^\s*__template__;$/m, templateTag);
+
+  writeFileSync(gjs, gjsSource, { encoding: 'utf8' });
+}

--- a/src/steps/rename-js-to-gjs.ts
+++ b/src/steps/rename-js-to-gjs.ts
@@ -1,0 +1,49 @@
+import { execSync } from 'node:child_process';
+import { existsSync, readFileSync, renameSync, writeFileSync } from 'node:fs';
+import path from 'node:path';
+
+import type { Options } from '../types/index.js';
+
+export default function renameJsToGjs(options: Options): void {
+  const src = path.join(
+    options.projectRoot,
+    options.filename.replace('.hbs', '.js'),
+  );
+
+  const dest = path.join(
+    options.projectRoot,
+    options.filename.replace('.hbs', '.gjs'),
+  );
+
+  if (existsSync(src)) {
+    if (readFileSync(src, { encoding: 'utf8' }).includes(`.extend(`)) {
+      throw new Error(
+        `It appears to be a classic class, convert it to native class first!`,
+      );
+    }
+
+    renameSync(src, dest);
+  } else {
+    if (options.filename.includes('/components/')) {
+      writeFileSync(
+        dest,
+        `import Component from "@glimmer/component";\n` +
+          `\n` +
+          `export default class extends Component {\n` +
+          `}\n`,
+        { encoding: 'utf8' },
+      );
+    } else {
+      throw new Error(`It does not appear to be a component!`);
+    }
+  }
+
+  const label = path.basename(options.filename).replace('.hbs', '');
+  const message = JSON.stringify(`DEV: mv chat/${label} -> gjs`);
+
+  execSync('git add .', { cwd: options.projectRoot });
+  execSync(`git commit -m ${message}`, {
+    cwd: options.projectRoot,
+    stdio: 'ignore',
+  });
+}

--- a/src/steps/resolve-imports.ts
+++ b/src/steps/resolve-imports.ts
@@ -1,0 +1,652 @@
+import { existsSync, readFileSync, writeFileSync } from 'node:fs';
+import path, { join } from 'node:path';
+
+import { AST } from '@codemod-utils/ast-template';
+import { KEYWORDS_TYPES, type KeywordType } from '@glimmer/syntax';
+import { AST as GLimmerAST } from 'ember-template-recast';
+
+import type { CodemodOptions, Options } from '../types/index.js';
+
+type PathExpression = GLimmerAST.PathExpression;
+
+export default function resolveImports(options: Options): void {
+  const hbs = path.join(options.projectRoot, options.filename);
+
+  const hbsSource = readFileSync(hbs, { encoding: 'utf8' });
+
+  const gjs = path.join(
+    options.projectRoot,
+    options.filename.replace('.hbs', '.gjs'),
+  );
+
+  const jsSource = readFileSync(gjs, { encoding: 'utf8' });
+
+  const hasActionImport = /^import.+action.+from "@ember\/object";$/m.test(
+    jsSource,
+  );
+
+  const traverse = AST.traverse();
+
+  const resolver = new Resolver(options);
+
+  const ast = traverse(hbsSource, {
+    BlockStatement: {
+      enter(node) {
+        if (node.path.type !== 'PathExpression') {
+          throw new Error('unexpected block type ' + node.path.type);
+        }
+
+        resolver.resolve('Block', node.path);
+      },
+
+      keys: {
+        program: {
+          enter(node) {
+            resolver.push(node.program.blockParams);
+          },
+          exit() {
+            resolver.pop();
+          },
+        },
+      },
+    },
+
+    ElementNode: {
+      enter(node) {
+        // e.g. `<this.foo>`
+        if (node.tag.includes('.')) {
+          return;
+        }
+
+        // e.g. `<@Foo>`
+        if (node.tag.startsWith('@')) {
+          return;
+        }
+
+        // e.g. `<:foo>`
+        if (node.tag.startsWith(':')) {
+          return;
+        }
+
+        // e.g. <li>
+        if (node.tag[0] === node.tag[0]?.toLowerCase()) {
+          return;
+        }
+
+        const resolved = resolver.resolveComponent(dasherize(node.tag));
+
+        if (resolved) {
+          if (node.tag !== resolved.identifier) {
+            // If we return in enter, the new node will get visited again
+            (node as { rename?: string }).rename = resolved.identifier;
+          }
+        }
+      },
+
+      keys: {
+        children: {
+          enter(node) {
+            resolver.push(node.blockParams);
+          },
+
+          exit() {
+            resolver.pop();
+          },
+        },
+      },
+
+      exit(node) {
+        const { rename } = node as { rename?: string };
+
+        if (rename) {
+          return AST.builders.element(rename, {
+            attrs: node.attributes,
+            modifiers: node.modifiers,
+            children: node.children,
+            comments: node.comments,
+            blockParams: node.blockParams,
+            loc: node.loc,
+          });
+        } else {
+          return node;
+        }
+      },
+    },
+
+    ElementModifierStatement(node) {
+      if (node.path.type !== 'PathExpression') {
+        throw new Error('unexpected mustache type ' + node.path.type);
+      }
+
+      if (hasActionImport && node.path.original === 'action') {
+        throw new Error(
+          'The template contains usage of the {{action}} keyword, ' +
+            'but the JS side imports { action } from @ember/object. ' +
+            'It would have shadowed the template keyword.',
+        );
+      }
+
+      const resolved = resolver.resolve('Modifier', node.path);
+
+      if (resolved) {
+        if (node.path.original !== resolved.identifier) {
+          node.path = AST.builders.path(resolved.identifier);
+        }
+      }
+    },
+
+    MustacheStatement(node) {
+      // {{true}}, etc
+      if (node.path.type !== 'PathExpression') {
+        return;
+      }
+
+      if (hasActionImport && node.path.original === 'action') {
+        throw new Error(
+          'The template contains usage of the {{action}} keyword, ' +
+            'but the JS side imports { action } from @ember/object. ' +
+            'It would have shadowed the template keyword.',
+        );
+      }
+
+      if (node.path.original === 'component') {
+        throw new Error(
+          'The template contains usage of the {{component}} keyword, ' +
+            'this is potentially unsafe because strict mode templates ' +
+            'cannot use {{component}} keyword for string-based resolution. ' +
+            'If it is only used for arguments currying, that is fine, ' +
+            'but this codemod is not currently sophisticated enough to ' +
+            'tell the difference.',
+        );
+      }
+
+      const resolved = resolver.resolve('Append', node.path);
+
+      if (resolved) {
+        if (node.path.original !== resolved.identifier) {
+          node.path = AST.builders.path(resolved.identifier);
+        }
+      }
+    },
+
+    SubExpression(node) {
+      // (true), etc
+      if (node.path.type !== 'PathExpression') {
+        return;
+      }
+
+      if (hasActionImport && node.path.original === 'action') {
+        throw new Error(
+          'The template contains usage of the {{action}} keyword, ' +
+            'but the JS side imports { action } from @ember/object. ' +
+            'It would have shadowed the template keyword.',
+        );
+      }
+
+      if (node.path.original === 'component') {
+        throw new Error(
+          'The template contains usage of the (component) keyword, ' +
+            'this is potentially unsafe because strict mode templates ' +
+            'cannot use (component) keyword for string-based resolution. ' +
+            'If it is only used for arguments currying, that is fine, ' +
+            'but this codemod is not currently sophisticated enough to ' +
+            'tell the difference.',
+        );
+      }
+
+      const resolved = resolver.resolve('Call', node.path);
+
+      if (resolved) {
+        if (node.path.original !== resolved.identifier) {
+          node.path = AST.builders.path(resolved.identifier);
+        }
+      }
+    },
+  });
+
+  const hbsRewritten = AST.print(ast);
+  const jsRewritten = resolver.imports() + jsSource;
+
+  writeFileSync(hbs, hbsRewritten, { encoding: 'utf8' });
+  writeFileSync(gjs, jsRewritten, { encoding: 'utf8' });
+}
+
+function dasherize(camelized: string): string {
+  return camelized
+    .replace(/::/g, '/')
+    .replace(/([A-Z])/g, '-$1')
+    .replace(/^-/, '')
+    .replace(/\/-/g, '/')
+    .toLowerCase();
+}
+
+function identifierFor(dasherized: string, upperCase = false): string {
+  const parts = dasherized.split('/');
+  const name = parts[parts.length - 1];
+
+  if (!name) {
+    throw new Error('unexpected fail: ' + dasherized);
+  }
+
+  const words = name?.split('-').map((part) => {
+    return part.slice(0, 1).toUpperCase() + part.slice(1);
+  });
+
+  if (!upperCase) {
+    if (!words[0]) {
+      throw new Error('unexpected fail: ' + dasherized);
+    }
+
+    words[0] = words[0]?.toLowerCase();
+  }
+
+  return words?.join('');
+}
+
+interface ImportSpec {
+  importPath: string;
+  importType: 'default' | 'named';
+}
+
+interface Resolved extends ImportSpec {
+  identifier: string;
+}
+
+interface Search {
+  base: string;
+  module: string;
+}
+
+class Resolver {
+  private stack: string[][] = [];
+  private resolved = new Map<string, Resolved>();
+
+  constructor(private options: CodemodOptions) {}
+
+  push(locals: string[]) {
+    this.stack.push(locals);
+  }
+
+  pop() {
+    this.stack.pop();
+  }
+
+  resolve(type: KeywordType, path: PathExpression): Resolved | undefined {
+    if (path.tail.length !== 0) {
+      return;
+    }
+
+    if (path.head.type !== 'VarHead') {
+      return;
+    }
+
+    const name = path.head.name;
+
+    if (this.isLocal(name)) {
+      return;
+    }
+
+    if (this.isKeyword(type, name)) {
+      return;
+    }
+
+    let resolved = this.resolved.get(`${type}:${name}`);
+
+    if (!resolved) {
+      if (type === 'Block') {
+        resolved = this.resolveComponent(name, false);
+
+        if (resolved) {
+          throw new Error(
+            `{{#${name}}} appears to be a component, convert it to <AngleBracket> first`,
+          );
+        }
+      } else if (type === 'Append') {
+        resolved = this.resolveComponent(name, false);
+
+        if (resolved) {
+          throw new Error(
+            `{{${name}}} appears to be a component, convert it to <AngleBracket> first`,
+          );
+        }
+
+        resolved = this.resolveHelper(name);
+      } else if (type === 'Call') {
+        resolved = this.resolveHelper(name);
+      } else if (type === 'Modifier') {
+        resolved = this.resolveModifier(name);
+      } else {
+        throw new Error(`unreachable ${type} ${name}`);
+      }
+    }
+
+    if (resolved) {
+      this.resolved.set(`${type}:${name}`, resolved);
+      return resolved;
+    } else {
+      throw new Error(`Failed to resolve ${name} (${type})`);
+    }
+  }
+
+  imports(): string {
+    if (this.resolved.size === 0) {
+      return '';
+    }
+
+    // I thought we could rely on eslint to fix { default as Foo }
+    // and consolidate multiple import statements into one, but I
+    // guess we don't have that rule set up?
+
+    const normalized = new Map<string, string>();
+    const imports = new Map<string, Set<string>>();
+    const defaultImports = new Map<string, string>();
+
+    for (const { importPath } of this.resolved.values()) {
+      if (importPath.startsWith('discourse/plugins/chat')) {
+        let relativePath = path.relative(
+          path.dirname('discourse/plugins/chat/' + this.options.filename),
+          importPath,
+        );
+
+        if (!relativePath.startsWith('.')) {
+          relativePath = `./${relativePath}`;
+        }
+
+        normalized.set(importPath, relativePath);
+      } else {
+        normalized.set(importPath, importPath);
+      }
+
+      imports.set(importPath, new Set());
+    }
+
+    for (const {
+      identifier,
+      importPath,
+      importType,
+    } of this.resolved.values()) {
+      if (importType === 'default') {
+        defaultImports.set(importPath, identifier);
+      } else {
+        imports.get(importPath)!.add(identifier);
+      }
+    }
+
+    let statements = '';
+
+    for (const mod of imports) {
+      const path = JSON.stringify(normalized.get(mod[0]));
+      const parts = [];
+
+      const defaultImport = defaultImports.get(mod[0]);
+
+      if (defaultImport) {
+        parts.push(defaultImport);
+      }
+
+      if (mod[1].size) {
+        const namedImports = `{ ${[...mod[1]].join(', ')} }`;
+        parts.push(namedImports);
+      }
+
+      statements += `import ${parts.join(', ')} from ${path};\n`;
+    }
+
+    return statements;
+  }
+
+  isLocal(identifier: string): boolean {
+    return this.stack.flat().includes(identifier);
+  }
+
+  isKeyword(type: KeywordType, identifier: string): boolean {
+    // For some reason, these aren't included in the list,
+    // but should be
+    if (identifier === 'action') {
+      return true;
+    }
+
+    // And these are included in the list, but shouldn't be
+    if (identifier === 'link-to') {
+      return false;
+    }
+
+    const keywords = KEYWORDS_TYPES as {
+      [identifier: string]: KeywordType[] | undefined;
+    };
+
+    return keywords[identifier]?.includes(type) ?? false;
+  }
+
+  resolveComponent(name: string, required = true): Resolved | undefined {
+    let resolved = this.resolved.get(`Component:${name}`);
+
+    if (!resolved) {
+      switch (name) {
+        case 'input':
+          resolved = {
+            identifier: 'Input',
+            importPath: '@ember/component',
+            importType: 'named',
+          };
+          break;
+
+        case 'link-to':
+          resolved = {
+            identifier: 'LinkTo',
+            importPath: '@ember/routing',
+            importType: 'named',
+          };
+          break;
+
+        case 'textarea':
+          resolved = {
+            identifier: 'Textarea',
+            importPath: '@ember/component',
+            importType: 'named',
+          };
+          break;
+      }
+    }
+
+    if (!resolved) {
+      let spec = this.search(
+        name,
+        [
+          {
+            base: '/Users/godfrey/code/discourse/app/assets/javascripts/discourse/app/components',
+            module: 'discourse/components',
+          },
+          {
+            base: '/Users/godfrey/code/discourse/app/assets/javascripts/float-kit/addon/components',
+            module: 'float-kit/components',
+          },
+          {
+            base: '/Users/godfrey/code/discourse/app/assets/javascripts/select-kit/addon/components',
+            module: 'select-kit/components',
+          },
+          {
+            base: '/Users/godfrey/code/discourse/plugins/chat/assets/javascripts/discourse/components',
+            module: 'discourse/plugins/chat/discourse/components',
+          },
+        ],
+        ['.gjs', '.js', '.hbs'],
+      );
+
+      if (!spec) {
+        spec = this.search(
+          // discourse special: <Chat::Notices> -> chat-notices
+          name.replaceAll('/', '-'),
+          [
+            {
+              base: '/Users/godfrey/code/discourse/app/assets/javascripts/discourse/app/components',
+              module: 'discourse/components',
+            },
+            {
+              base: '/Users/godfrey/code/discourse/app/assets/javascripts/float-kit/addon/components',
+              module: 'float-kit/components',
+            },
+            {
+              base: '/Users/godfrey/code/discourse/app/assets/javascripts/select-kit/addon/components',
+              module: 'select-kit/components',
+            },
+            {
+              base: '/Users/godfrey/code/discourse/plugins/chat/assets/javascripts/discourse/components',
+              module: 'discourse/plugins/chat/discourse/components',
+            },
+          ],
+          ['.gjs', '.js', '.hbs'],
+        );
+      }
+
+      if (spec) {
+        resolved = {
+          identifier: identifierFor(name, true),
+          ...spec,
+        };
+      }
+    }
+
+    if (resolved) {
+      this.resolved.set(`Component:${name}`, resolved);
+    } else if (required) {
+      throw new Error(`Failed to resolve ${name} (Component)`);
+    }
+
+    return resolved;
+  }
+
+  resolveHelper(name: string): Resolved | undefined {
+    switch (name) {
+      case 'array':
+        return {
+          identifier: 'array',
+          importPath: '@ember/helper',
+          importType: 'named',
+        };
+      case 'concat':
+        return {
+          identifier: 'concat',
+          importPath: '@ember/helper',
+          importType: 'named',
+        };
+      case 'fn':
+        return {
+          identifier: 'fn',
+          importPath: '@ember/helper',
+          importType: 'named',
+        };
+      case 'get':
+        return {
+          identifier: 'get',
+          importPath: '@ember/helper',
+          importType: 'named',
+        };
+      case 'hash':
+        return {
+          identifier: 'hash',
+          importPath: '@ember/helper',
+          importType: 'named',
+        };
+    }
+
+    const spec: ImportSpec | undefined = this.search(
+      name,
+      [
+        {
+          base: '/Users/godfrey/code/discourse/app/assets/javascripts/discourse/app/helpers',
+          module: 'discourse/helpers',
+        },
+        {
+          base: '/Users/godfrey/code/discourse/app/assets/javascripts/discourse-common/addon/helpers',
+          module: 'discourse-common/helpers',
+        },
+        {
+          base: '/Users/godfrey/code/discourse/app/assets/javascripts/truth-helpers/addon/helpers',
+          module: 'truth-helpers/helpers',
+        },
+        {
+          base: '/Users/godfrey/code/discourse/plugins/chat/assets/javascripts/discourse/helpers',
+          module: 'discourse/plugins/chat/discourse/helpers',
+        },
+      ],
+      ['.js'],
+    );
+
+    if (spec) {
+      return {
+        identifier: identifierFor(name),
+        ...spec,
+      };
+    }
+  }
+
+  resolveModifier(name: string): Resolved | undefined {
+    switch (name) {
+      case 'on':
+        return {
+          identifier: 'on',
+          importPath: '@ember/modifier',
+          importType: 'named',
+        };
+
+      case 'did-insert':
+        return {
+          identifier: 'didInsert',
+          importPath: '@ember/render-modifiers/modifiers/did-insert',
+          importType: 'default',
+        };
+      case 'did-update':
+        return {
+          identifier: 'didUpdate',
+          importPath: '@ember/render-modifiers/modifiers/did-update',
+          importType: 'default',
+        };
+      case 'will-destroy':
+        return {
+          identifier: 'willDestroy',
+          importPath: '@ember/render-modifiers/modifiers/will-destroy',
+          importType: 'default',
+        };
+    }
+
+    let spec: ImportSpec | undefined;
+
+    if (name.startsWith('chat/')) {
+      spec = this.search(
+        name,
+        [
+          {
+            base: '/Users/godfrey/code/discourse/plugins/chat/assets/javascripts/discourse/modifiers',
+            module: 'discourse/plugins/chat/discourse/modifiers',
+          },
+        ],
+        ['.js'],
+      );
+    }
+
+    if (spec) {
+      return {
+        identifier: identifierFor(name),
+        ...spec,
+      };
+    }
+  }
+
+  search(
+    name: string,
+    searches: Search[],
+    extensions: string[],
+  ): ImportSpec | undefined {
+    for (const search of searches) {
+      for (const extension of extensions) {
+        if (existsSync(join(search.base, name + extension))) {
+          return {
+            importPath: `${search.module}/${name}`,
+            importType: 'default',
+          };
+        }
+      }
+    }
+  }
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,10 +1,12 @@
 type CodemodOptions = {
   appName: string;
+  filename: string;
   projectRoot: string;
 };
 
 type Options = {
   appName: string;
+  filename: string;
   projectRoot: string;
 };
 


### PR DESCRIPTION
This is not so much a PR intended to be merged, but rather just sharing the quick and dirty code I wrote for a specific task, and perhaps the code here can be useful to others as a starting point. (Thanks @IgnaceMaes for getting it started!)

Hardcoded a bunch of things to make it work with Discourse – the chat plugin to be specific.

We have a bunch of custom resolver rules that needs to be ported over to make this work.

The overall strategry should be generalizable. We have a bunch of custom resolver logic that needs to be ported over, the average app can probably try to share code with the Embroider resolver – or use the Resolver from `@embroider/core` directly with `.resolver.json`.

See https://github.com/discourse/discourse/pull/24260 for how this code was used in context.